### PR TITLE
If there are no LUNs, don't error

### DIFF
--- a/getData
+++ b/getData
@@ -241,7 +241,7 @@ run.run_command(['pvs', '--noheadings'], 'pvs', fail_ok=True, sort=True)
 run.run_command(['parted', '-l', '-s'], 'partitions', fail_ok=False, sort=False)
 if os.path.exists('/sbin/powermt'):
     run.run_command(['powermt', 'display', 'dev=all'],
-                    'powermt', fail_ok=False, sort=False, stdout=False)
+                    'powermt', fail_ok=True, sort=False, stdout=False)
     run.run_command(['rpm', '-q', 'EMCpower.LINUX',
                     'bfa_util_linux_noioctl', 'bfa_driver_linux'],
                     'san_packages', fail_ok=True, sort=True)


### PR DESCRIPTION
If PowerPath is installed, but no LUNs are present, powermt display dev=all exits 1:

```
# powermt display dev=all
Device(s) not found.
# echo $?
1
```

This means getData throws an error, however there is nothing wrong here. Instead we'll allow powermt to exit non-zero.
