### PR TITLE
Added pacemaker status & constraints

### DIFF
--- a/configsnap
+++ b/configsnap
@@ -189,7 +189,7 @@ if not os.path.isdir(workdir):
     except OSError:
         report_error("Unable to create %s" % workdir)
 
-os.chdir(workdir) 
+os.chdir(workdir)
 
 if not "PATH" in os.environ:
   os.environ['PATH'] = '/usr/bin:/bin'
@@ -278,6 +278,11 @@ report_info("Getting cluster status...")
 if os.path.exists('/usr/sbin/clustat'):
     run.run_command(['clustat', '-l'], 'clustat',
                     fail_ok=False, sort=False, stdout=False)
+if os.path.exists('/usr/sbin/pcs'):
+    run.run_command(['pcs', 'status'], 'pcs_status',
+                    fail_ok=False, sort=False, stdout=False)
+    run.run_command(['pcs', 'constraint', 'list'], 'pcs_constraints',
+                    fail_ok=False, sort=False, stdout=False)
 
 report_info("Getting misc (dmesg, lspci, sysctl)...")
 run.run_command(['dmesg'], 'dmesg', fail_ok=False, sort=False)
@@ -339,7 +344,7 @@ if os.path.exists(hpasmpath):
             # This returns something like:
             # "Smart Array P400 in Slot 1"
             stor_cmd = subprocess.Popen(
-                [storutil, 'controller', 'all', 'show'], 
+                [storutil, 'controller', 'all', 'show'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stor_out = stor_cmd.stdout.readlines()
             stor_cmd.wait()
@@ -402,7 +407,7 @@ if ('post' in phase or 'rollback' in phase) and not options.silent_enabled:
 
     report_info("This is  %s  phase so performing diffs..." % phase)
 
-    for filename in ('sysvinit', 'mounts', 'netstat', 'ip_addresses', 
+    for filename in ('sysvinit', 'mounts', 'netstat', 'ip_addresses',
                      'ip_routes', 'partitions', 'lspci'):
         run.get_diff(filename)
 
@@ -415,7 +420,7 @@ if ('post' in phase or 'rollback' in phase) and not options.silent_enabled:
                      'hpreport_server','hpreport_memory','hpreport_bios',
                      'hpreport_storage_controller','hpreport_storage_vdisk',
                      'hpreport_storage_pdisk', 'multipath', 'systemdinit',
-                     'upstartinit', 'yum.conf', 'dnf.conf'):
+                     'upstartinit', 'yum.conf', 'dnf.conf', 'pcs_constraints'):
         pre_filename = os.path.join(workdir,
                                     "%s.pre" % filename)
         if os.path.exists(pre_filename):


### PR DESCRIPTION
Changes for Pacemaker clusters:

Added `pcs status` and `pcs constraint list` to output files
Added diff of `pcs constraint list` to post/rollback stage (to detect if you accidentally leave a new resource constraint in place after manually migrating services)