### PR TITLE
Switch to using shell diff to ignore whitespace

### DIFF
--- a/configsnap
+++ b/configsnap
@@ -22,7 +22,6 @@ import grp
 import sys
 import subprocess
 import datetime
-import difflib
 import glob
 import re
 import shutil
@@ -300,21 +299,22 @@ class dataGather:
                          (e.filename, e.strerror))
             return False
 
-        pre = pre_fd.readlines()
-        post = post_fd.readlines()
-        pre_fd.close()
-        post_fd.close()
-        found_diff = False
-        for line in difflib.ndiff(pre, post):
-            if line[0] in ('+', '-', '?'):
-                if not found_diff:
-                    found_diff = True
-                    diffs_found_msg = True
-                    report_error(
-                        "Differences found against %s.%s:\n" % (filename, options.pre_suffix))
-                sys.stdout.write(line)
+        try:
+            diff_proc = subprocess.Popen(['diff', '-B', '-b', pre_filename, post_filename],
+                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
+        except OSError, e:
+            report_error("Error running %s: %s" %
+                         (command[0], e.strerror))
+            return None
 
-        if not found_diff:
+        if diff_proc.wait() != 0:
+            found_diff = True
+            diffs_found_msg = True
+            report_error(
+                "Differences found against %s.%s:\n" %(filename, options.pre_suffix))
+
+            sys.stdout.writelines(diff_proc.stdout.readlines())
+        else:
             report_info("No differences against %s.%s" % (filename, options.pre_suffix))
 
     def __init__(self, workdir, phase):

--- a/configsnap
+++ b/configsnap
@@ -200,9 +200,11 @@ def compare_files():
     if diffs_found_msg:
         report_info_blue("\nINTERPRETING DIFFS:\n")
         report_info_blue(
-            "* Lines beginning with a - show an entry from the " + options.pre_suffix + " pre file which has changed\nor which is not present in the .post or .rollback file.\n")
+            "* Lines beginning with a < show an entry from the " + options.pre_suffix + " pre file which has changed\n"
+            "or which is not present in the .post or .rollback file.\n")
         report_info_blue(
-            "* Lines beginning with a + show an entry from the .post or.rollback file which\nhas changed or which is not present in the " + options.pre_suffix + " pre file.\n")
+            "* Lines beginning with a > show an entry from the .post or.rollback file which\n"
+            "has changed or which is not present in the " + options.pre_suffix + " pre file.\n")
         report_info_blue(
             "Please review all diff output above carefully and account for any differences\nfound.\n")
 

--- a/configsnap
+++ b/configsnap
@@ -311,7 +311,7 @@ class dataGather:
             found_diff = True
             diffs_found_msg = True
             report_error(
-                "Differences found against %s.%s:\n" %(filename, options.pre_suffix))
+                "Differences found against %s.%s:\n" % (filename, options.pre_suffix))
 
             sys.stdout.writelines(diff_proc.stdout.readlines())
         else:


### PR DESCRIPTION
Resolves rackerlabs/configsnap/issues/30, remove difflib and use the diff
command with -B and -b options to ignore blank lines and differences in
whitespace.

Output looks like:
```
root@centos6:~/whitespace/configsnap# configsnap -w -p post -t whitespace
post files exist in /root/whitespace/configsnap. Overwrite (-w/--overwrite) enabled so removing.
Getting storage details (LVM, partitions, multipathing)...
Getting process list...
Getting package list and enabled services...
Getting network details, firewall rules and listening services...
Getting cluster status...
Getting misc (dmesg, lspci, sysctl)...
Copying files...
 /boot/grub/grub.conf
 /etc/fstab
 /etc/hosts
 /etc/sysconfig/network
 /etc/yum.conf
 /proc/cmdline
 /proc/meminfo
 /proc/mounts
 /proc/scsi/scsi
 /etc/sysconfig/network-scripts/ifcfg-lo
 /etc/sysconfig/network-scripts/ifcfg-eth1
 /etc/sysconfig/network-scripts/ifcfg-eth0


This is  post  phase so performing diffs...
No differences against /root/whitespace/configsnap/sysvinit.pre
No differences against /root/whitespace/configsnap/mounts.pre
No differences against /root/whitespace/configsnap/netstat.pre
No differences against /root/whitespace/configsnap/ip_addresses.pre
No differences against /root/whitespace/configsnap/ip_routes.pre
No differences against /root/whitespace/configsnap/partitions.pre
No differences against /root/whitespace/configsnap/lspci.pre
No differences against /root/whitespace/configsnap/lvs.pre
No differences against /root/whitespace/configsnap/pvs.pre
No differences against /root/whitespace/configsnap/vgs.pre
No differences against /root/whitespace/configsnap/upstartinit.pre
Differences found against /root/whitespace/configsnap/yum.conf.pre:

26c26
< #excludes=configsnap*
---
> excludes=configsnap*

INTERPRETING DIFFS:

* Lines beginning with a - show an entry from the .pre file which has changed
or which is not present in the .post or .rollback file.

* Lines beginning with a + show an entry from the .post or.rollback file which
has changed or which is not present in the .pre file.

Please review all diff output above carefully and account for any differences
found.

Finished! Backups were saved to /root/whitespace/configsnap/*.post
```