### PR TITLE
Update copy_dir function to include subdirectories

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,17 +1,17 @@
 configsnap is maintained by:
 ```
-	- Paolo Gigante
-        - Nicholas Rhodes
+    - Paolo Gigante
+    - Nicholas Rhodes
+    - Jean-Yves Michaud
 ```
 
 Original author at Rackspace (http://www.rackspace.co.uk):
 ```
-	- Cian Brennan
+    - Cian Brennan
 ```
 
 Major contributors:
 ```
-        - Cameron Beere
-        - Piers Cornwell
+    - Cameron Beere
+    - Piers Cornwell
 ```
-

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 configsnap NEWS
 
+0.15
+ * Added new function `copy_dir` to backup the content of an entire directory
+
 0.14
  * Adjusted -w option to only overwrite specific tagged files
  * Add option to compare existing files without gathering new data using the -C/--compare-only option
@@ -29,7 +32,7 @@ configsnap NEWS
  * Added man page
  * Record dm-multipath information
  * Continue if lvm isn't present
- * Allow PowerPath to be present, but with no LUNs 
+ * Allow PowerPath to be present, but with no LUNs
 
 0.10
  * Initial public release

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # configsnap
 
-Records useful system state information, and compare to previous state if run with PHASE containing "post" or "rollback".
+Records useful system state information, and compare to previous state if run
+with PHASE containing "post" or "rollback".
 
-Tested on RHEL, CentOS, Fedora and Ubuntu, but should also work on other derivatives. For other distros, config will be collected where the commands or file locations match RHEL or Ubuntu.
+Tested on RHEL, CentOS, Fedora and Ubuntu, but should also work on other
+derivatives. For other distros, config will be collected where the commands or
+file locations match RHEL or Ubuntu.
 
 ```
 Usage: configsnap [options]
@@ -43,27 +46,29 @@ Getting cluster status...
 Getting misc (dmesg, lspci, sysctl)...
 Getting Dell hardware information...
 Copying files...
- /boot/grub/grub.conf 
- /etc/fstab 
- /etc/hosts 
- /etc/sysconfig/network 
- /etc/yum.conf 
- /proc/cmdline 
- /proc/meminfo 
- /proc/mounts 
- /proc/scsi/scsi 
- /etc/sysconfig/network-scripts/ifcfg-eth3 
- /etc/sysconfig/network-scripts/ifcfg-lo 
- /etc/sysconfig/network-scripts/ifcfg-eth1 
- /etc/sysconfig/network-scripts/ifcfg-eth0 
- /etc/sysconfig/network-scripts/ifcfg-eth2 
- /etc/sysconfig/network-scripts/route-eth2 
+ /boot/grub/grub.conf
+ /etc/fstab
+ /etc/hosts
+ /etc/sysconfig/network
+ /etc/yum.conf
+ /proc/cmdline
+ /proc/meminfo
+ /proc/mounts
+ /proc/scsi/scsi
+ /etc/sysconfig/network-scripts/ifcfg-eth3
+ /etc/sysconfig/network-scripts/ifcfg-lo
+ /etc/sysconfig/network-scripts/ifcfg-eth1
+ /etc/sysconfig/network-scripts/ifcfg-eth0
+ /etc/sysconfig/network-scripts/ifcfg-eth2
+ /etc/sysconfig/network-scripts/route-eth2
 
 
 Finished! Backups were saved to /root/junepatching/configsnap/*.pre
 ```
 
-Custom collection of additional command output (Type: command) and files (Type: file) can be configured in the file /etc/configsnap/additional.conf, for example:
+Custom collection of additional command output (Type: command) and files (Type:
+file) can be configured in the file /etc/configsnap/additional.conf, for
+example:
 
 ```
 [psspecial]

--- a/additional.conf
+++ b/additional.conf
@@ -6,6 +6,10 @@
 # File: [ source filename ]
 #
 # [section]
+# Type: directory
+# Directory: [ full command to run ]
+#
+# [section]
 # Type: command
 # File: [ full command to run ]
 # Sort: [ True | False ] (optional)
@@ -23,3 +27,7 @@
 # [debconf.conf]
 # Type: file
 # File: /etc/debconf.conf
+#
+# [ssh]
+# Type: directory
+# Directory: /etc/ssh/

--- a/additional.conf
+++ b/additional.conf
@@ -8,6 +8,7 @@
 # [section]
 # Type: directory
 # Directory: [ full command to run ]
+# File_Pattern: [ regular expression to match filenames ]
 #
 # [section]
 # Type: command
@@ -31,3 +32,4 @@
 # [ssh]
 # Type: directory
 # Directory: /etc/ssh/
+# File_Pattern: sshd.*

--- a/configsnap
+++ b/configsnap
@@ -395,13 +395,15 @@ class dataGather:
             elif options.verbose_enabled is True:
                 report_verbose("No differences against %s" % pre_filename)
 
-        if diffs_found_msg is False:
-            report_info("No differences found for files in %s" % sdir)
-
         # Looking for new files
         for post_filename in glob.glob(sdir + '/*' + self.phase):
             if post_filename not in all_pre_files:
                 report_error("+ File added: %s:" % post_filename)
+                diffs_found_msg = True
+
+        if diffs_found_msg is False:
+            report_info("No differences found for files in %s" % sdir)
+
 
     def __init__(self, workdir, phase):
         self.workdir = workdir

--- a/configsnap
+++ b/configsnap
@@ -28,7 +28,7 @@ import shutil
 import tarfile
 
 
-version = "0.14"
+version = "0.15"
 diffs_found_msg = False
 is_php_detected = False
 
@@ -173,9 +173,12 @@ def compare_files():
             cfgtype = Config.get(section, 'type').lower()
             if Config.has_option(section, 'compare') and Config.get(section, 'compare').lower() == "true":
                 additional_to_compare_files.append(section)
-        except Exception, e:
+        except ConfigParser.NoOptionError, e:
             report_error(
                 "Check config file options for section %s: %s" % (section, e))
+        except Exception, e:
+            report_error(
+                "Could not parse config file section %s: %s" % (section, e))
 
     compare_files.extend(additional_to_compare)
 
@@ -411,7 +414,10 @@ class dataGather:
 #
 ###################################################
 
-desc = 'Record useful system state information, and compare to previous state if run with PHASE containing "post" or "rollback".'
+desc = ("Record useful system state information, and compare to previous state "
+       "if run with PHASE containing \"post\" or \"rollback\".\nAn optional file, "
+       "/etc/configsnap/additional.conf, can be provided for extra files, "
+       "directories or command to register during configsnap execution.")
 
 parser = optparse.OptionParser(description=desc)
 parser.add_option('-w', '--overwrite',
@@ -512,9 +518,10 @@ if os.path.exists(customcollectionfile):
 # Ensure each section has a valid Type
 for section in Config.sections():
     if Config.has_option(section, 'type'):
-        if Config.get(section, 'type').lower() != "file" and Config.get(section, 'type').lower() != "command":
+        if not re.match('^(file|directory|command)$', Config.get(section, 'type').lower()):
+        #if Config.get(section, 'type').lower() != "file" and Config.get(section, 'type').lower() != "command":
             report_error(
-                "Wrong \"Type\" defined for custom collection entry \"%s\"; should be \"file\" or \"command\"" % section)
+                "Wrong \"Type\" defined for custom collection entry \"%s\"; should be \"file\", \"directory\" or \"command\"" % section)
 
 # Get a list of processes running on the server
 procs = subprocess.Popen(
@@ -720,9 +727,12 @@ for section in Config.sections():
             report_info("Running custom command %s: %s" % (section, cmd))
             run.run_command(
                 cmd.split(), section, fail_ok=failokcfg, sort=sortcfg)
-    except Exception, e:
+    except ConfigParser.NoOptionError, e:
         report_error(
             "Check config file options for section %s: %s" % (section, e))
+    except Exception, e:
+        report_error(
+            "Could not parse config file section %s: %s" % (section, e))
 
 # copy important files
 report_info("Copying files...")
@@ -750,24 +760,33 @@ if os.path.exists('/etc/sysconfig/network-scripts/'):
     run.copy_dir('/etc/sysconfig/network-scripts/', file_pattern='(ifcfg-|route-).*',
                  fail_ok=False, sort=False)
 
-# copy custom files
+# copy custom files and directories
 for section in Config.sections():
     try:
+        # Optional options
+        if Config.has_option(section, 'failok') and Config.get(section, 'failok').lower() == "true":
+            failokcfg = True
+        # If failok is anything except true...
+        else:
+                failokcfg = False
+
         cfgtype = Config.get(section, 'type').lower()
         if cfgtype == 'file':
             cpfile = Config.get(section, 'file')
-
-            # Optional options
-            if Config.has_option(section, 'failok') and Config.get(section, 'failok').lower() == "true":
-                failokcfg = True
-            # If failok is anything except true...
-            else:
-                failokcfg = False
-
             run.copy_file(cpfile, fail_ok=failokcfg)
-    except Exception, e:
+
+        elif cfgtype == 'directory':
+            cpdir = Config.get(section, 'directory')
+            if not cpdir.endswith("/"):
+                cpdir = cpdir + '/'
+            run.copy_dir(cpdir, fail_ok=failokcfg, sort=False)
+
+    except ConfigParser.NoOptionError, e:
         report_error(
             "Check config file options for section %s: %s" % (section, e))
+    except Exception, e:
+        report_error(
+            "Could not parse config file section %s: %s" % (section, e))
 
 report_info("\n")
 

--- a/configsnap
+++ b/configsnap
@@ -415,9 +415,9 @@ class dataGather:
 ###################################################
 
 desc = ("Record useful system state information, and compare to previous state "
-       "if run with PHASE containing \"post\" or \"rollback\".\nAn optional file, "
-       "/etc/configsnap/additional.conf, can be provided for extra files, "
-       "directories or command to register during configsnap execution.")
+        "if run with PHASE containing \"post\" or \"rollback\".\nAn optional file, "
+        "/etc/configsnap/additional.conf, can be provided for extra files, "
+        "directories or command to register during configsnap execution.")
 
 parser = optparse.OptionParser(description=desc)
 parser.add_option('-w', '--overwrite',
@@ -519,7 +519,7 @@ if os.path.exists(customcollectionfile):
 for section in Config.sections():
     if Config.has_option(section, 'type'):
         if not re.match('^(file|directory|command)$', Config.get(section, 'type').lower()):
-        #if Config.get(section, 'type').lower() != "file" and Config.get(section, 'type').lower() != "command":
+            # if Config.get(section, 'type').lower() != "file" and Config.get(section, 'type').lower() != "command":
             report_error(
                 "Wrong \"Type\" defined for custom collection entry \"%s\"; should be \"file\", \"directory\" or \"command\"" % section)
 
@@ -550,8 +550,8 @@ if os.path.exists('/sbin/lvs'):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         vgcfg.wait()
-    except:
-        report_error("vgcfgbackup failed")
+    except OSError, e:
+        report_error("Error running vgcfgbackup: %s" % e.strerror)
     else:
         if vgcfg.returncode != 0:
             report_error("vgcfg exited with return code %d" % vgcfg.returncode)

--- a/configsnap
+++ b/configsnap
@@ -767,7 +767,7 @@ for section in Config.sections():
             failokcfg = True
         # If failok is anything except true...
         else:
-                failokcfg = False
+            failokcfg = False
 
         cfgtype = Config.get(section, 'type').lower()
         if cfgtype == 'file':
@@ -776,9 +776,14 @@ for section in Config.sections():
 
         elif cfgtype == 'directory':
             cpdir = Config.get(section, 'directory')
+            if Config.has_option(section, 'file_pattern'):
+                config_file_pattern = Config.get(section, 'file_pattern')
+            else:
+                config_file_pattern = '.*'
+
             if not cpdir.endswith("/"):
                 cpdir = cpdir + '/'
-            run.copy_dir(cpdir, fail_ok=failokcfg, sort=False)
+            run.copy_dir(cpdir, file_pattern=config_file_pattern, fail_ok=failokcfg, sort=False)
 
     except ConfigParser.NoOptionError, e:
         report_error(

--- a/configsnap
+++ b/configsnap
@@ -222,6 +222,13 @@ class dataGather:
         if destdir is None:
             destdir = self.workdir
 
+        if not os.path.exists(destdir):
+            try:
+                os.makedirs(destdir)
+            except OSError, e:
+                report_error("Unable to create directory %s" % (workdir, e))
+                sys.exit(1)
+
         if not os.path.exists(r_filename):
             if not fail_ok:
                 report_error(" %s does not exist" % r_filename)
@@ -259,19 +266,15 @@ class dataGather:
                 report_error(" Directory %s does not exist" % destdir)
             return
 
-        if not os.path.exists(destdir):
-            try:
-                os.makedirs(destdir)
-            except OSError, e:
-                report_error("Unable to create directory %s" % (workdir, e))
-                sys.exit(1)
+        for root, dirs, files in os.walk(srcdir):
+            for cfile in files:
+                if not os.path.islink(os.path.join(root, cfile)):
+                    self.copy_file(os.path.join(root, cfile),
+                                   destdir=os.path.join(destdir, root.replace(srcdir, '')),
+                                   fail_ok=False,
+                                   sort=False)
 
-        for filename in os.listdir(srcdir):
-            # We are explicitly overriding the destdir for the copy_file function
-            self.copy_file(srcdir + filename, destdir=destdir, fail_ok=False, sort=False)
-
-    def run_command(self, command, filename, fail_ok=False,
-                    sort=False, stdout=False, shell=False):
+    def run_command(self, command, filename, fail_ok=False, sort=False, stdout=False, shell=False):
         try:
             command_proc = subprocess.Popen(
                 command, stdout=subprocess.PIPE,
@@ -714,6 +717,9 @@ if os.path.exists('/usr/bin/php'):
     run.copy_file('/etc/php.ini', fail_ok=True)
     if os.path.exists('/etc/php.d'):
         run.copy_dir('/etc/php.d/', fail_ok=False, sort=False)
+
+    if os.path.exists('/etc/php/'):
+        run.copy_dir('/etc/php/', fail_ok=False, sort=False)
 
     run.run_command(
         ['php', '-m'], 'php_modules', fail_ok=False, sort=False)

--- a/configsnap
+++ b/configsnap
@@ -83,12 +83,17 @@ def create_dir(tagdir, overwrite):
     workdir = os.path.join(tagdir, "configsnap")
     if os.path.isdir(workdir) and overwrite:
         try:
-            if any(options.phase in s for s in os.listdir(workdir)):
-                report_info(
-                    "%s files exist in %s. Overwrite (-w/--overwrite) enabled so removing." % (options.phase, workdir))
-                for reportfile in os.listdir(workdir):
-                    if options.phase in reportfile:
-                        os.remove(os.path.join(workdir, reportfile))
+            # We need to go through all subdirs as well
+            for root, dirs, files in os.walk(workdir):
+                if any(s.endswith(".%s" % options.phase) for s in files):
+                    report_info(
+                        "%s files exist in %s. Overwrite (-w/--overwrite) enabled so removing." % (options.phase, root))
+
+                # actual removal
+                for filename in files:
+                    if filename.endswith(".%s" % options.phase):
+                        os.remove(os.path.join(root, filename))
+
         except OSError, e:
             report_error("Unable to remove %s: %s" % (workdir, e))
             sys.exit(1)
@@ -348,8 +353,15 @@ class dataGather:
 
     def get_diff_dir(self, sdir):
         diffs_found_msg = False
+        all_pre_files = []
         sdir = os.path.join(workdir, sdir)
+
         for pre_filename in glob.glob(sdir + '/*' + options.pre_suffix):
+
+            # building list of all 'pre' files
+            bare_file = os.path.splitext(pre_filename)[0] + '.' + self.phase
+            all_pre_files.append(bare_file)
+
             post_filename = "%s.%s" % (os.path.splitext(pre_filename)[0],
                                        self.phase)
 
@@ -357,9 +369,8 @@ class dataGather:
                 pre_fd = open(pre_filename)
                 post_fd = open(post_filename)
             except IOError, e:
-                report_error("Unable to open file %s: %s" %
-                             (e.filename, e.strerror))
-                return False
+                report_error("- File removed: %s" % (e.filename))
+                continue
 
             try:
                 diff_proc = subprocess.Popen(['diff', '--unified=0',
@@ -384,10 +395,21 @@ class dataGather:
         if diffs_found_msg is False:
             report_info("No differences found for files in %s" % sdir)
 
+        # Looking for new files
+        for post_filename in glob.glob(sdir + '/*' + self.phase):
+            if post_filename not in all_pre_files:
+                report_error("+ File added: %s:" % post_filename)
+
     def __init__(self, workdir, phase):
         self.workdir = workdir
         self.phase = phase
 
+
+###################################################
+#
+#                   MAIN
+#
+###################################################
 
 desc = 'Record useful system state information, and compare to previous state if run with PHASE containing "post" or "rollback".'
 
@@ -453,11 +475,13 @@ os.environ['PATH'] += ':/usr/sbin:/sbin'
 
 if options.phase:
     phase = options.phase
-    for filename in os.listdir('.'):
-        if filename.endswith(".%s" % phase) and not options.compare_only:
-            report_error("Files for %s already exist in %s" % (phase,
-                                                               os.getcwd()))
-            sys.exit(1)
+    # We need to go into subdirs as well for checking
+    for root, dirs, files in os.walk(workdir):
+        for filename in files:
+            if filename.endswith(".%s" % phase) and not options.compare_only:
+                report_error("Files for %s already exist in %s" % (phase,
+                                                                   os.getcwd()))
+                sys.exit(1)
 else:
     now = datetime.datetime.now()
     phase = "%d%02d%02d%02d%02d" % (now.year, now.month, now.day,

--- a/configsnap
+++ b/configsnap
@@ -139,38 +139,31 @@ def compare_files():
         report_error("Unable to diff, as no " + options.pre_suffix + " pre files")
         sys.exit(0)
 
-    report_info("This is  %s  phase so performing diffs..." % phase)
+    report_info("\nThis is %s phase so performing file diffs..." % phase)
 
     if 'rollback' in phase:
-        run.get_diff('packages')
+        run.get_diff_files('packages')
 
-    compare = ['sysvinit', 'mounts', 'netstat', 'ip_addresses', 'network',
-               'interfaces', 'hosts', 'lvs', 'pvs', 'vgs', 'fstab', 'powermt',
-               'omreport_version', 'ip_routes', 'partitions', 'lspci',
-               'omreport_memory', 'omreport_processors', 'omreport_nics',
-               'omreport_vdisk', 'omreport_pdisk', 'hpreport_server',
-               'hpreport_memory', 'hpreport_bios',
-               'hpreport_storage_controller', 'hpreport_storage_vdisk',
-               'hpreport_storage_pdisk', 'multipath', 'systemdinit',
-               'upstartinit', 'yum.conf', 'dnf.conf', 'pcs_constraints',
-               'sudoers']
+    compare_files = ['sysvinit', 'mounts', 'netstat', 'ip_addresses',
+                     'network', 'interfaces', 'hosts', 'lvs', 'pvs', 'vgs',
+                     'fstab', 'powermt', 'omreport_version', 'ip_routes',
+                     'partitions', 'lspci', 'omreport_memory',
+                     'omreport_processors', 'omreport_nics', 'omreport_vdisk',
+                     'omreport_pdisk', 'hpreport_server', 'hpreport_memory',
+                     'hpreport_bios', 'hpreport_storage_controller',
+                     'hpreport_storage_vdisk', 'hpreport_storage_pdisk',
+                     'multipath', 'systemdinit', 'upstartinit', 'yum.conf',
+                     'dnf.conf', 'pcs_constraints', 'sudoers']
 
     # Add network config files
     for filename in glob.glob('/etc/sysconfig/network-scripts/ifcfg-*'):
-        compare.append(os.path.basename(filename))
+        compare_files.append(os.path.basename(filename))
 
     # Add php files if detected
     if is_php_detected:
-        compare.append('php.ini')
+        compare_files.append('php.ini')
         if os.path.exists('/usr/bin/pecl'):
-            compare.append('pecl-list')
-
-    # Append all files in all subdirectories to the compare list
-    for directory in os.listdir(workdir):
-        if os.path.isdir(os.path.join(workdir, directory)):
-            for subdir_file in os.listdir(os.path.join(workdir, directory)):
-                if not os.path.join(directory, os.path.splitext(subdir_file)[0]) in compare:
-                    compare.append(os.path.join(directory, os.path.splitext(subdir_file)[0]))
+            compare_files.append('pecl-list')
 
     # Array to hold custom collection files and commands to compare
     additional_to_compare = []
@@ -178,18 +171,25 @@ def compare_files():
         try:
             cfgtype = Config.get(section, 'type').lower()
             if Config.has_option(section, 'compare') and Config.get(section, 'compare').lower() == "true":
-                additional_to_compare.append(section)
+                additional_to_compare_files.append(section)
         except Exception, e:
             report_error(
                 "Check config file options for section %s: %s" % (section, e))
 
-    compare.extend(additional_to_compare)
+    compare_files.extend(additional_to_compare)
 
-    for filename in compare:
+    for filename in compare_files:
         pre_filename = os.path.join(workdir,
                                     "%s.%s" % (filename, options.pre_suffix))
         if os.path.exists(pre_filename):
-            run.get_diff(filename)
+            run.get_diff_files(filename)
+
+    # Report subdirectories at the subdir level unless ther verbose option is
+    # given, in which case report as usual
+    report_info("\nStarting sub-dir diffs...")
+    for directory in os.listdir(workdir):
+        if os.path.isdir(os.path.join(workdir, directory)):
+            run.get_diff_dir(directory)
 
     try:
         uname_pre_fd = open(
@@ -258,7 +258,7 @@ class dataGather:
         except IOError:
             report_error("Error copying %s" % w_filename)
 
-    def copy_dir(self, srcdir, destdir=None, fail_ok=False, sort=False):
+    def copy_dir(self, srcdir, file_pattern='.*', destdir=None, fail_ok=False, sort=False):
         # Did we override the destination
         if destdir is None:
             destdir = os.path.join(self.workdir, os.path.basename(os.path.dirname(srcdir)))
@@ -270,7 +270,7 @@ class dataGather:
 
         for root, dirs, files in os.walk(srcdir):
             for cfile in files:
-                if not os.path.islink(os.path.join(root, cfile)):
+                if re.match(file_pattern, cfile) and not os.path.islink(os.path.join(root, cfile)):
                     self.copy_file(os.path.join(root, cfile),
                                    destdir=os.path.join(destdir, root.replace(srcdir, '')),
                                    fail_ok=False,
@@ -320,7 +320,7 @@ class dataGather:
         if stdout:
             sys.stdout.writelines(output)
 
-    def get_diff(self, filename):
+    def get_diff_files(self, filename):
         global diffs_found_msg
         filename = os.path.join(self.workdir, filename)
         pre_filename = "%s.%s" % (filename, options.pre_suffix)
@@ -350,9 +350,48 @@ class dataGather:
         else:
             report_info("No differences against %s.%s" % (filename, options.pre_suffix))
 
+    def get_diff_dir(self, sdir):
+        diffs_found_msg = False
+        sdir = os.path.join(workdir,  sdir)
+        for pre_filename in glob.glob(sdir + '/*' + options.pre_suffix):
+            post_filename = "%s.%s" % (os.path.splitext(pre_filename)[0],
+                                       self.phase)
+
+            try:
+                pre_fd = open(pre_filename)
+                post_fd = open(post_filename)
+            except IOError, e:
+                report_error("Unable to open file %s: %s" %
+                             (e.filename, e.strerror))
+                return False
+
+            try:
+                diff_proc = subprocess.Popen(['diff', '--unified=0',
+                                              '--ignore-blank-lines',
+                                              '--ignore-space-change',
+                                              pre_filename, post_filename],
+                                             stdout=subprocess.PIPE,
+                                             stderr=subprocess.PIPE,
+                                             shell=False)
+            except OSError, e:
+                report_error("Error running %s: %s" %
+                             (command[0], e.strerror))
+                return None
+
+            if diff_proc.wait() != 0:
+                diffs_found_msg = True
+                report_error("Differences found against %s:\n" % pre_filename)
+                sys.stdout.writelines(diff_proc.stdout.readlines())
+            elif options.verbose_enabled is True:
+                report_verbose("No differences against %s" % pre_filename)
+
+        if diffs_found_msg is False:
+            report_info("No differences found for files in %s" % sdir)
+
     def __init__(self, workdir, phase):
         self.workdir = workdir
         self.phase = phase
+
 
 desc = 'Record useful system state information, and compare to previous state if run with PHASE containing "post" or "rollback".'
 
@@ -686,10 +725,10 @@ run.copy_file('/etc/sudoers', fail_ok=False, sort=False)
 run.copy_dir('/etc/sudoers.d/', fail_ok=False, sort=False)
 if os.path.exists('/etc/network/interfaces.d'):
     run.copy_dir('/etc/network/interfaces.d/', fail_ok=False, sort=False)
-for filename in glob.glob('/etc/sysconfig/network-scripts/ifcfg-*'):
-    run.copy_file(filename, fail_ok=False)
-for filename in glob.glob('/etc/sysconfig/network-scripts/route-*'):
-    run.copy_file(filename, fail_ok=False)
+
+if os.path.exists('/etc/sysconfig/network-scripts/'):
+    run.copy_dir('/etc/sysconfig/network-scripts/', file_pattern='(ifcfg-|route-).*',
+                 fail_ok=False, sort=False)
 
 # copy custom files
 for section in Config.sections():

--- a/configsnap
+++ b/configsnap
@@ -155,10 +155,6 @@ def compare_files():
                      'multipath', 'systemdinit', 'upstartinit', 'yum.conf',
                      'dnf.conf', 'pcs_constraints', 'sudoers']
 
-    # Add network config files
-    for filename in glob.glob('/etc/sysconfig/network-scripts/ifcfg-*'):
-        compare_files.append(os.path.basename(filename))
-
     # Add php files if detected
     if is_php_detected:
         compare_files.append('php.ini')
@@ -352,7 +348,7 @@ class dataGather:
 
     def get_diff_dir(self, sdir):
         diffs_found_msg = False
-        sdir = os.path.join(workdir,  sdir)
+        sdir = os.path.join(workdir, sdir)
         for pre_filename in glob.glob(sdir + '/*' + options.pre_suffix):
             post_filename = "%s.%s" % (os.path.splitext(pre_filename)[0],
                                        self.phase)

--- a/configsnap
+++ b/configsnap
@@ -417,7 +417,7 @@ class dataGather:
 desc = ("Record useful system state information, and compare to previous state "
         "if run with PHASE containing \"post\" or \"rollback\".\nAn optional file, "
         "/etc/configsnap/additional.conf, can be provided for extra files, "
-        "directories or command to register during configsnap execution.")
+        "directories or commands to register during configsnap execution.")
 
 parser = optparse.OptionParser(description=desc)
 parser.add_option('-w', '--overwrite',
@@ -519,7 +519,6 @@ if os.path.exists(customcollectionfile):
 for section in Config.sections():
     if Config.has_option(section, 'type'):
         if not re.match('^(file|directory|command)$', Config.get(section, 'type').lower()):
-            # if Config.get(section, 'type').lower() != "file" and Config.get(section, 'type').lower() != "command":
             report_error(
                 "Wrong \"Type\" defined for custom collection entry \"%s\"; should be \"file\", \"directory\" or \"command\"" % section)
 

--- a/configsnap
+++ b/configsnap
@@ -404,7 +404,6 @@ class dataGather:
         if diffs_found_msg is False:
             report_info("No differences found for files in %s" % sdir)
 
-
     def __init__(self, workdir, phase):
         self.workdir = workdir
         self.phase = phase

--- a/configsnap.help2man
+++ b/configsnap.help2man
@@ -5,19 +5,24 @@
 
 [Custom Collection]
 
-Commands are all run as root, so the custom collection configuration file must be owned by root and not read or writable by other users. The file format is:
+Commands are all run as root, so the custom collection configuration file must
+be owned by root and not read or writable by other users. The file format is:
 
 \ [section] - The name of the output file, and the status message for this collection
- Type - "command", to run a command, or "file" to save a file
+ Type - "command", to run a command, "file" to save a file, or "directory" to
+ recursively backup a directory.
  Command - When Type = command, the fully qualified command to run, e.g. /bin/ss -tanp
  File - The fully qualified path to a file to save, e.g. /etc/debconf.conf
+ Directory - The path to the directory with trailing '/'
 
 For "command", there is the following additional optional setting:
  Sort - save output sorted (default: False)
 
 For either "command" or "file", the are the follow additional optional settings:
- Failok - True/False - Whether to report problems running the command or copying the file (default: False)
- Compare - True/False - Whether to compare output when phase contains post or rollback (default: False)
+ Failok - True/False - Whether to report problems running the command or
+ copying the file (default: False)
+ Compare - True/False - Whether to compare output when phase contains post or
+ rollback (default: False)
 
 Examples:
 
@@ -31,4 +36,10 @@ Examples:
  File: /etc/debconf.conf
  Failok: True
 
-These would record two files per run, psspecial.phase and debconf.conf.phase.
+\ [ssh]
+ Type: directory
+ Directory: /etc/ssh/
+
+These would record two files per run, psspecial.phase and debconf.conf.phase,
+along with the content of the /etc/ssh/ directory with sub-files appended with
+.phase.


### PR DESCRIPTION
Fix for #72 so that the copy_dir function copies the source directory
tree including subdirectories. It will skip symlinks.