### PR TITLE
fixing apache-related files comparison

### DIFF
--- a/configsnap
+++ b/configsnap
@@ -31,6 +31,7 @@ import tarfile
 version = "0.15"
 diffs_found_msg = False
 is_php_detected = False
+is_apache_detected = False
 
 
 def report_verbose(message):
@@ -165,6 +166,11 @@ def compare_files():
         compare_files.append('php.ini')
         if os.path.exists('/usr/bin/pecl'):
             compare_files.append('pecl-list')
+
+    # Add apache files if detected
+    if is_apache_detected:
+        compare_files.append('httpd_modules')
+        compare_files.append('httpd_vhosts')
 
     # Array to hold custom collection files and commands to compare
     additional_to_compare = []
@@ -694,6 +700,7 @@ if os.path.exists(hpasmpath):
 
 if '/usr/sbin/httpd' in procs_output or '/usr/sbin/httpd.worker' in procs_output:
     report_info("Getting Apache vhosts and modules...")
+    is_apache_detected = True
     run.run_command(
         ['httpd', '-S'], 'httpd_vhosts', fail_ok=False, sort=False)
     run.run_command(


### PR DESCRIPTION
Addressing #81 

Tested successfully on centos 7
```
/usr/local/share/configsnap/configsnap -t http -p post -d /home/test --pre test1 -w

[..]

Differences found against /home/test/http/configsnap/httpd_modules.test1:

--- /home/jean/http/configsnap/httpd_modules.test1      2018-09-13 14:12:00.604826680 +0000
+++ /home/jean/http/configsnap/httpd_modules.post       2018-09-13 14:14:17.848738657 +0000
@@ -32 +31,0 @@
- dumpio_module (shared)
Differences found against /home/test/http/configsnap/httpd_vhosts.test1:

--- /home/jean/http/configsnap/httpd_vhosts.test1       2018-09-13 14:12:00.548826716 +0000
+++ /home/jean/http/configsnap/httpd_vhosts.post        2018-09-13 14:14:17.784738698 +0000
@@ -5 +5,2 @@
-         port 80 namevhost dummy.local (/etc/httpd/conf.d/dummy2.conf:1)
+         port 80 namevhost dummy2.local (/etc/httpd/conf.d/dummy2.conf:1)
+         port 80 namevhost dummy3.local (/etc/httpd/conf.d/dummy3.conf:1)
@@ -9,3 +9,0 @@
-Mutex proxy: using_defaults
-Mutex authn-socache: using_defaults
-Mutex default: dir="/run/httpd/" mechanism=default
@@ -16,0 +15,3 @@
+Mutex proxy: using_defaults
+Mutex authn-socache: using_defaults
+Mutex default: dir="/run/httpd/" mechanism=default
```