### PR TITLE
updating README.md file with newly added --config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage: configsnap [options]
 
 Record useful system state information, and compare to previous state if run
 with PHASE containing "post" or "rollback". A default config file,
-/etc/configsnap/additional.conf, can be provided for extra files, directories
+/etc/configsnap/additional.conf, can be customised to include extra files, directories
 or commands to register during configsnap execution.
 
 Options:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Options:
                         comparison
   -c CONFIG, --config=CONFIG
                         additional config file to use. Setting this will
-                        overwrite default.
+                        override default.
 ```
 
 Example output:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ file locations match RHEL or Ubuntu.
 Usage: configsnap [options]
 
 Record useful system state information, and compare to previous state if run
-with PHASE containing "post" or "rollback".
+with PHASE containing "post" or "rollback". An optional file,
+/etc/configsnap/additional.conf, can be provided for extra files, directories
+or commands to register during configsnap execution.
 
 Options:
   -h, --help            show this help message and exit
@@ -33,6 +35,9 @@ Options:
                         and --phase
   --pre=PRE_SUFFIX      suffix for files captured at previous state, for
                         comparison
+  -c CONFIG, --config=CONFIG
+                        additional config file to use. Setting this will
+                        overwrite default.
 ```
 
 Example output:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ file locations match RHEL or Ubuntu.
 Usage: configsnap [options]
 
 Record useful system state information, and compare to previous state if run
-with PHASE containing "post" or "rollback". An optional file,
+with PHASE containing "post" or "rollback". A default config file,
 /etc/configsnap/additional.conf, can be provided for extra files, directories
 or commands to register during configsnap execution.
 


### PR DESCRIPTION
Just updating the Readme file from the output of `-h` option.