### PR TITLE
Convert relative basedir to absolute path

### DIFF
--- a/configsnap
+++ b/configsnap
@@ -512,7 +512,8 @@ elif customcollectionfile != '/etc/configsnap/additional.conf':
                  % customcollectionfile)
     sys.exit(1)
 
-tagdir = os.path.join(options.basedir, options.tag)
+# os.path.abspath to deal with relavive paths
+tagdir = os.path.join(os.path.abspath(options.basedir), options.tag)
 workdir = create_dir(tagdir, options.overwrite_enabled)
 os.chdir(workdir)
 


### PR DESCRIPTION
We chdir into workdir, then in dataGather.copy_file we check to see if
workdir exists relative to the cwd, which is already workdir. This
causes a second set of folders to be created to workdir, from within the
original workdir.