### PR TITLE
Ignore flake8 warning W605

### DIFF
--- a/configsnap
+++ b/configsnap
@@ -614,7 +614,7 @@ if os.path.exists('/usr/bin/systemctl'):
 report_info(
     "Getting network details, firewall rules and listening services...")
 run.run_command(['bash', '-c', 'ip a s | sed "/^\s\+valid_lft.*/d"'],
-                'ip_addresses', fail_ok=False, sort=False)
+                'ip_addresses', fail_ok=False, sort=False)  # noqa: W605
 run.run_command(['ip', 'route', 'show'],
                 'ip_routes', fail_ok=False, sort=False)
 run.run_command(['iptables', '--list-rules'],


### PR DESCRIPTION
flake8 incorrectly believes that the regex is being run by python, not sed.