### PR TITLE
Integrate rpm build patch to hardcode python binary

### DIFF
--- a/configsnap
+++ b/configsnap
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright 2016 Rackspace, Inc.
 #


### PR DESCRIPTION
This renders the following patch no longer necessary:
https://src.fedoraproject.org/rpms/configsnap/blob/master/f/python_executable.patch