### PR TITLE
Rework build files, add patch for python exe path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 BUILD
+rpmbuild

--- a/configsnap
+++ b/configsnap
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Copyright 2016-2021 Rackspace, Inc.
 #
@@ -28,7 +28,7 @@ import glob
 import re
 import tarfile
 
-version = "0.19.0"
+version = "0.20.0"
 diffs_found = False
 
 

--- a/configsnap.spec
+++ b/configsnap.spec
@@ -1,14 +1,17 @@
-Name:          configsnap
-Version:       0.19.0
-Release:       1%{?dist}
-Summary:       Record and compare system state
-License:       ASL 2.0
-URL:           https://github.com/rackerlabs/%{name}
-Source0:       https://github.com/rackerlabs/%{name}/archive/%{version}.tar.gz
-# Changes the python shebang to python2
-BuildArch:     noarch
-BuildRequires: python2-devel
-BuildRequires: help2man
+Name:           configsnap
+Version:        0.20.0
+Release:        3%{?dist}
+Summary:        Record and compare system state
+License:        ASL 2.0
+URL:            https://github.com/rackerlabs/%{name}
+Source0:        https://github.com/rackerlabs/%{name}/archive/%{version}.tar.gz
+BuildArch:      noarch
+BuildRequires:  help2man
+%if 0%{?rhel} >= 8 || 0%{?fedora}
+BuildRequires:  python3
+%else
+BuildRequires:  python2
+%endif
 
 %description
 configsnap records important system state information and can optionally compare
@@ -40,6 +43,12 @@ install -p -m 0600 additional.conf %{buildroot}%{_sysconfdir}/%{name}/additional
 %{_sysconfdir}/%{name}
 
 %changelog
+* Fri May 07 2021 Nick Rhodes <nrhodes91@gmail.com> - 0.20.0-3
+- Fix build issues in Koji
+
+* Fri May 07 2021 Nick Rhodes <nrhodes91@gmail.com> - 0.20.0-1
+- Port to python3 compatibility (PR 120)
+
 * Sun Aug 16 2020 Nick Rhodes <nrhodes91@gmail.com> - 0.19.0-1
 - Added lsblk and blkid (PR 115)
 - Fix flake8 warnings (PR 118)

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/rackerlabs/configsnap
 
 Package: configsnap
 Depends:
-    python, python2.7, diffutils
+    python3, diffutils
 Architecture: all
 Description: configsnap records important system state information and can
     optionally compare with a previous state and identify changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,32 @@
 version: '3'
 services:
-  el6:
-    build:
-      context: .
-      dockerfile: ./dockerfiles/Dockerfile-el6
-    volumes:
-      - .:/home/builduser/configsnap
-      - ~/rpmbuild/RPMS:/home/builduser/rpmbuild/RPMS
-      - ~/rpmbuild/SOURCES:/home/builduser/rpmbuild/SOURCES
-
-  el7:
-    build:
-      context: .
-      dockerfile: ./dockerfiles/Dockerfile-el7
-    volumes:
-      - .:/home/builduser/configsnap
-      - ~/rpmbuild/RPMS:/home/builduser/rpmbuild/RPMS
-      - ~/rpmbuild/SOURCES:/home/builduser/rpmbuild/SOURCES
-
-  fedora:
+  fedora: &rhelconfig
     build:
       context: .
       dockerfile: ./dockerfiles/Dockerfile-fedora
     volumes:
       - .:/home/builduser/configsnap
-      - ~/rpmbuild/RPMS:/home/builduser/rpmbuild/RPMS
-      - ~/rpmbuild/SOURCES:/home/builduser/rpmbuild/SOURCES
-
-  deb:
+      - ./rpmbuild/RPMS:/home/builduser/rpmbuild/RPMS
+      - ./rpmbuild/SRPMS:/home/builduser/rpmbuild/SRPMS
+      - ./rpmbuild/SOURCES:/home/builduser/rpmbuild/SOURCES
+  el8:
+    <<: *rhelconfig
     build:
       context: .
-      dockerfile: ./dockerfiles/Dockerfile-deb
+      dockerfile: ./dockerfiles/Dockerfile-el8
+  el7:
+    <<: *rhelconfig
+    build:
+      context: .
+      dockerfile: ./dockerfiles/Dockerfile-el7
+  el6:
+    <<: *rhelconfig
+    build:
+      context: .
+      dockerfile: ./dockerfiles/Dockerfile-el6
+  buster:
+    build:
+      context: .
+      dockerfile: ./dockerfiles/Dockerfile-buster
     volumes:
       - .:/home/builduser/configsnap

--- a/dockerfiles/Dockerfile-buster
+++ b/dockerfiles/Dockerfile-buster
@@ -1,6 +1,6 @@
-FROM debian:latest
+FROM debian:buster
 RUN apt update \
-    && apt install -y python devscripts build-essential gawk help2man \
+    && apt install -y python devscripts build-essential gawk help2man lsb-release \
     && groupadd -g 1004 builduser \
     && useradd -m -u 1003 -g builduser builduser
 

--- a/dockerfiles/Dockerfile-el6
+++ b/dockerfiles/Dockerfile-el6
@@ -1,6 +1,7 @@
 FROM centos:6
-RUN yum install -q -y git rpm-build rpm-devel rpmlint make python rpmdevtools \
-    help2man python2-devel \
+RUN sed -ri -e 's/mirrorlist/#mirrorlist/' -e 's;#baseurl=http://mirror.centos.org/centos/\$releasever/;baseurl=http://vault.centos.org/6.10/;' /etc/yum.repos.d/CentOS-Base.repo
+RUN yum install -q -y git rpm-build rpm-devel rpmlint make python rpmdevtools redhat-lsb-core \
+        help2man \
     && groupadd -g 1004 builduser \
     && useradd -m -u 1003 -g builduser builduser
 
@@ -8,4 +9,4 @@ USER builduser
 RUN mkdir /home/builduser/configsnap \
     && rpmdev-setuptree
 WORKDIR /home/builduser/configsnap
-CMD ["make","el6"]
+CMD ["make","rpm"]

--- a/dockerfiles/Dockerfile-el7
+++ b/dockerfiles/Dockerfile-el7
@@ -1,6 +1,6 @@
 FROM centos:7
-RUN yum install -q -y git rpm-build rpm-devel rpmlint make python rpmdevtools \
-    help2man python2-devel \
+RUN yum install -q -y git rpm-build rpm-devel rpmlint make python rpmdevtools help2man \
+        redhat-lsb-core \
     && groupadd -g 1004 builduser \
     && useradd -m -u 1003 -g builduser builduser
 
@@ -8,4 +8,4 @@ USER builduser
 RUN mkdir /home/builduser/configsnap \
     && rpmdev-setuptree
 WORKDIR /home/builduser/configsnap
-CMD ["make","el7"]
+CMD ["make","rpm"]

--- a/dockerfiles/Dockerfile-el8
+++ b/dockerfiles/Dockerfile-el8
@@ -1,0 +1,12 @@
+FROM centos:8
+RUN yum install -y epel-release && yum install --enablerepo powertools -q -y git \
+        rpm-build rpm-devel rpmlint epel-rpm-macros make python3 python3-devel \
+        rpmdevtools help2man redhat-lsb-core \
+    && groupadd -g 1004 builduser \
+    && useradd -m -u 1003 -g builduser builduser
+
+USER builduser
+RUN mkdir /home/builduser/configsnap \
+    && rpmdev-setuptree
+WORKDIR /home/builduser/configsnap
+CMD ["make","rpm"]

--- a/dockerfiles/Dockerfile-fedora
+++ b/dockerfiles/Dockerfile-fedora
@@ -1,6 +1,6 @@
 FROM fedora:latest
 RUN dnf install -y git rpm-build rpm-devel rpmlint make python2 rpmdevtools \
-    help2man python2-devel \
+        help2man python2-devel redhat-lsb-core \
     && groupadd -g 1004 builduser \
     && useradd -m -u 1003 -g builduser builduser
 
@@ -8,4 +8,4 @@ USER builduser
 RUN mkdir /home/builduser/configsnap \
     && rpmdev-setuptree
 WORKDIR /home/builduser/configsnap
-CMD ["make","fedora"]
+CMD ["make","rpm"]

--- a/patches/001-python-exec.patch
+++ b/patches/001-python-exec.patch
@@ -1,0 +1,10 @@
+diff --git a/configsnap b/configsnap
+index b4143dd..b2a92c1 100755
+--- a/configsnap
++++ b/configsnap
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python3
++#!/usr/bin/python
+ 
+ # Copyright 2016-2021 Rackspace, Inc.
+ #


### PR DESCRIPTION
Clean up Makefile so it's not spewing unknown command errors on osx.
Include patches to adjust python executable patch based on distro
version.

Adding epel-rpm-macros to CentOS8 image due to
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2019-b4e9aea40d

Bump version to 0.20.0-3 for releases
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2021-2397845783
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2021-6892560c81