### PR TITLE
Accommodate for multiple lines in readlines

### DIFF
--- a/configsnap
+++ b/configsnap
@@ -389,7 +389,10 @@ class dataGather:
                 global diffs_found
                 diffs_found = True
                 report_error("Differences found against %s:\n" % pre_filename)
-                sys.stdout.writelines(diff_proc.stdout.readlines())
+                output = diff_proc.stdout.readlines()
+                if isinstance(output, list):
+                    output = '\n'.join(str(x) for x in output)
+                sys.stdout.writelines(output)
             elif options.verbose_enabled is True:
                 report_verbose("No differences against %s" % pre_filename)
 


### PR DESCRIPTION
The `readlines()` method may return multiple lines which need to be stitched together to avoid stdout attempt to parse a list object rather than an expected string.  This aims to permit multiple lines.