### PR TITLE
Handle scenario when a device is running with a latin1 locale

### DIFF
--- a/configsnap
+++ b/configsnap
@@ -18,6 +18,7 @@ try:
 except ImportError:
     # Python2 compatibility
     import ConfigParser as configparser
+import locale
 import os
 import os.path
 import optparse
@@ -30,7 +31,7 @@ import tarfile
 
 version = "0.21.1"
 diffs_found = False
-
+encoding = locale.getpreferredencoding()
 
 def report_verbose(message):
     if options.verbose_enabled:
@@ -276,7 +277,7 @@ class dataGather:
         cmd_stdout, cmd_stderr = cmd_proc.communicate()
         if not isinstance(cmd_stdout, str):
             # Python3 returns bytes
-            cmd_stdout, cmd_stderr = cmd_stdout.decode('utf8'), cmd_stderr.decode('utf8')
+            cmd_stdout, cmd_stderr = cmd_stdout.decode(encoding), cmd_stderr.decode(encoding)
 
         # Convert stdout to a list and preserve the newlines
         cmd_stdout = cmd_stdout.splitlines(True)

--- a/configsnap
+++ b/configsnap
@@ -277,7 +277,8 @@ class dataGather:
         cmd_stdout, cmd_stderr = cmd_proc.communicate()
         if not isinstance(cmd_stdout, str):
             # Python3 returns bytes
-            cmd_stdout, cmd_stderr = cmd_stdout.decode(encoding), cmd_stderr.decode(encoding)
+            cmd_stdout = cmd_stdout.decode(encoding, errors='replace')
+            cmd_stderr = cmd_stderr.decode(encoding, errors='replace')
 
         # Convert stdout to a list and preserve the newlines
         cmd_stdout = cmd_stdout.splitlines(True)

--- a/configsnap
+++ b/configsnap
@@ -277,8 +277,8 @@ class dataGather:
         cmd_stdout, cmd_stderr = cmd_proc.communicate()
         if not isinstance(cmd_stdout, str):
             # Python3 returns bytes
-            cmd_stdout = cmd_stdout.decode(encoding, errors='replace')
-            cmd_stderr = cmd_stderr.decode(encoding, errors='replace')
+            cmd_stdout = cmd_stdout.decode(encoding, errors="replace")
+            cmd_stderr = cmd_stderr.decode(encoding, errors="replace")
 
         # Convert stdout to a list and preserve the newlines
         cmd_stdout = cmd_stdout.splitlines(True)


### PR DESCRIPTION
Commands currently execute with the locale configured on the device. The explicit "utf8" decode of command output can be problematic if we have a scenario where a device is set to use latin1 and the executed command has a Unicode character in the output. 

```
Getting storage details (LVM, partitions, multipathing, lsblk, blkid)...
Getting process list...
Getting package list and enabled services...
Getting network details, firewall rules and listening services...
Getting cluster status...
Getting misc (dmesg, lspci, sysctl)...
Traceback (most recent call last):
  File "/root/configsnap", line 651, in <module>
    run.run_command(['dmesg'], 'dmesg', fail_ok=False, sort=False)
  File "/root/configsnap", line 279, in run_command
    cmd_stdout, cmd_stderr = cmd_stdout.decode('utf8'), cmd_stderr.decode('utf8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 246457: invalid continuation byte
```

This is just the least invasive to basically get around configsnap from failing but I know the encoding when we write the files will be utf8 - so it becomes the classic encoding slippery slope. Even if I matched encoding output of the files we write out (in the case of python3 only) it would still result in garbled looking text in the file for these problematic characters. 

The only other alternative might be to force "en_US.UTF-8" in the environment on the commands we run but not sure if that is ideal.